### PR TITLE
autocorrelation normalized to area

### DIFF
--- a/notebooks/SemiPhysicalModel/SemiPhysicalModel_v1.ipynb
+++ b/notebooks/SemiPhysicalModel/SemiPhysicalModel_v1.ipynb
@@ -452,7 +452,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pass time equals to 3.5971e-02 seconds\n"
+      "Pass time equals to 2.7902e-02 seconds\n"
      ]
     }
    ],
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "bf700403",
    "metadata": {},
    "outputs": [
@@ -523,7 +523,7 @@
     "fig, ax = plt.subplots(figsize = (10,8))\n",
     "ax.scatter(time, profile_TL, label = r\"Tr. Limited of $E(\\nu)$\", marker = \"+\", s = 40)\n",
     "ax.plot(time_control, profile_control, label = \"Control\", color = \"tab:orange\")\n",
-    "ax.plot(timeA, autocorrelation, label = 'AC')\n",
+    "ax.plot(timeA, autocorrelation/autocorrelation.max(), label = 'AC')\n",
     "\n",
     "ax.legend(fontsize = 12)\n",
     "ax.set_xlabel(\"Time (s)\", fontsize = 12)\n",

--- a/utils/LaserModel.py
+++ b/utils/LaserModel.py
@@ -258,7 +258,8 @@ class LaserModel:
         intensity_time = np.real(field_time * np.conj(field_time)) # only for casting reasons
         intensity_time = intensity_time / intensity_time.max() # normalizing intensity
         autocorrelation = np.correlate(intensity_time, np.conj(intensity_time), mode='same')
-        autocorrelation = autocorrelation / autocorrelation.max()
+        autocorrelation = autocorrelation / autocorrelation.max() #normalize to maximum
+        autocorrelation = autocorrelation / autocorrelation.sum() #normalize to area
         return time, autocorrelation
 
     def forward_pass(self, control:np.array) -> np.array: 


### PR DESCRIPTION
change the normalization to go from max = 1 to area = 1 with area being calculated as the sum of the array

this means that the arrays must be always compared with the same temporal resolutions otherwise the area will not be the same